### PR TITLE
Implement clean command

### DIFF
--- a/src/forge/cli/commands/clean.py
+++ b/src/forge/cli/commands/clean.py
@@ -1,9 +1,69 @@
-# src/forge/cli/commands/clean.py
+"""Implementation of the ``forge clean`` command."""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+import shutil
 
 import typer
+from rich.console import Console
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
 
-app = typer.Typer()
+from ...core.schema import Base, ProjectState
+
+
+app = typer.Typer(help="Remove generated artefacts and reset project state")
+console = Console()
+
+
+def _get_version() -> str:
+    """Return the installed Forge version or a sensible default."""
+
+    try:
+        return version("forge")
+    except PackageNotFoundError:  # pragma: no cover - best effort fallback
+        return "0.0.0"
+
 
 @app.callback(invoke_without_command=True)
-def clean():
-    pass
+def clean() -> None:
+    """Remove the ``.forge`` directory and recreate an empty state database.
+
+    This command keeps the ``forge.toml`` configuration file but discards all
+    generated artefacts.  A fresh ``.forge`` directory and SQLite database are
+    created so the project can be processed again from the beginning.
+    """
+
+    project_root = Path.cwd()
+    config_path = project_root / "forge.toml"
+    forge_dir = project_root / ".forge"
+
+    if not config_path.exists():
+        console.print("[red]No 'forge.toml' configuration file found.[/red]")
+        raise typer.Exit(code=1)
+
+    if forge_dir.exists():
+        shutil.rmtree(forge_dir)
+        console.print(f"[yellow]Removed existing directory {forge_dir}[/yellow]")
+
+    forge_dir.mkdir()
+    db_path = forge_dir / "forge.sqlite3"
+    engine = create_engine(f"sqlite:///{db_path}")
+    Base.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        session.add(
+            ProjectState(
+                project_name=project_root.name,
+                forge_version=_get_version(),
+            )
+        )
+        session.commit()
+
+    console.print(f"[green]Reinitialised project database at {db_path}[/green]")
+    console.print("[bold green]Project cleaned successfully.[/bold green]")
+
+
+__all__ = ["app"]

--- a/tests/cli/test_clean.py
+++ b/tests/cli/test_clean.py
@@ -1,0 +1,50 @@
+import sqlite3
+
+from typer.testing import CliRunner
+
+from forge.cli.main import app
+
+
+def test_clean_resets_project_state(tmp_path, monkeypatch):
+    """Ensure ``forge clean`` removes artifacts and resets the state database."""
+
+    runner = CliRunner()
+    monkeypatch.chdir(tmp_path)
+
+    # Initialise project to create configuration and state database
+    result = runner.invoke(app, ["init"])
+    assert result.exit_code == 0
+
+    forge_dir = tmp_path / ".forge"
+    # Create a dummy file to emulate generated artefacts
+    dummy = forge_dir / "dummy.txt"
+    dummy.write_text("junk")
+
+    # Run clean command
+    result = runner.invoke(app, ["clean"])
+    assert result.exit_code == 0
+
+    # Directory should exist but dummy file removed
+    assert forge_dir.is_dir()
+    assert not dummy.exists()
+
+    db_path = forge_dir / "forge.sqlite3"
+    assert db_path.exists()
+
+    # Database should contain a single project_state row in INITIALIZED state
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute("SELECT project_name, fsm_status FROM project_state")
+    row = cur.fetchone()
+    conn.close()
+
+    assert row == (tmp_path.name, "INITIALIZED")
+
+    # No file records should remain
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM file_records")
+    count = cur.fetchone()[0]
+    conn.close()
+
+    assert count == 0


### PR DESCRIPTION
## Summary
- implement `forge clean` to reset project state and remove generated artefacts
- add test verifying clean command reinitialises project database

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a20c323228832ead9e584c705f8480